### PR TITLE
blindscan Add FEC_4_5

### DIFF
--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -660,6 +660,7 @@ class Blindscan(ConfigListScreen, Screen):
 						"FEC_1_2" : parm.FEC_1_2,
 						"FEC_2_3" : parm.FEC_2_3,
 						"FEC_3_4" : parm.FEC_3_4,
+						"FEC_4_5" : parm.FEC_4_5,
 						"FEC_5_6": parm.FEC_5_6,
 						"FEC_7_8" : parm.FEC_7_8,
 						"FEC_8_9" : parm.FEC_8_9,


### PR DESCRIPTION
<   565.571650> Traceback (most recent call last):
<   565.571782>   File "/usr/lib/enigma2/python/Plugins/SystemPlugins/Blindscan/plugin.py", line 684, in blindscanContainerClose
<   565.576301>     parm.fec = fec[data[7]]
<   565.576637> KeyError: 'FEC_4