### PR TITLE
autotimer: change plugin for new version Seriesplugin (betonme)

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -392,12 +392,14 @@ class AutoTimer:
 			# Initialize
 			newEntry = None
 			oldExists = False
+			allow_modify = True
 
 			# Eventually change service to alternative
 			if timer.overrideAlternatives:
 				serviceref = timer.getAlternative(serviceref)
 
 			if timer.series_labeling and sp_getSeasonEpisode is not None:
+				allow_modify = False
 				#doLog("[AutoTimer SeriesPlugin] Request name, desc, path %s %s %s" % (name,shortdesc,dest))
 				sp = sp_getSeasonEpisode(serviceref, name, evtBegin, evtEnd, shortdesc, dest)
 				if sp and type(sp) in (tuple, list) and len(sp) == 4:
@@ -405,6 +407,7 @@ class AutoTimer:
 					shortdesc = sp[1] or shortdesc
 					dest = sp[2] or dest
 					doLog(str(sp[3]))
+					allow_modify = True
 					#doLog("[AutoTimer SeriesPlugin] Returned name, desc, path %s %s %s" % (name,shortdesc,dest))
 				else:
 					# Nothing found
@@ -418,6 +421,7 @@ class AutoTimer:
 							shortdesc = sp[1] or shortdesc
 							dest = sp[2] or dest
 							doLog(str(sp[3]))
+							allow_modify = True
 							#doLog("[AutoTimer SeriesPlugin] Returned name, desc, path %s %s %s" % (name,shortdesc,dest))
 						else:
 							doLog(str(sp))
@@ -543,10 +547,14 @@ class AutoTimer:
 
 				modified += 1
 
-				self.modifyTimer(newEntry, name, shortdesc, begin, end, serviceref, eit)
-				msg = "[AutoTimer] AutoTimer modified timer: %s ." % (newEntry.name)
-				doLog(msg)
-				newEntry.log(501, msg)
+				if allow_modify:
+					self.modifyTimer(newEntry, name, shortdesc, begin, end, serviceref, eit)
+					msg = "[AutoTimer] AutoTimer modified timer: %s ." % (newEntry.name)
+					doLog(msg)
+					newEntry.log(501, msg)
+				else:
+					msg = "[AutoTimer] AutoTimer modification not allowed for timer: %s ." % (newEntry.name)
+					doLog(msg)
 			else:
 				newEntry = RecordTimerEntry(ServiceReference(serviceref), begin, end, name, shortdesc, eit)
 
@@ -655,9 +663,6 @@ class AutoTimer:
 						# We might want to do the sanity check locally so we don't run it twice - but I consider this workaround a hack anyway
 						conflicts = recordHandler.record(newEntry)
 
-		if sp_showResult is not None:
-			sp_showResult()
-
 		return (new, modified)
 
 	def parseEPG(self, simulateOnly=False, uniqueId=None, callback=None):
@@ -719,6 +724,10 @@ class AutoTimer:
 					new += tup[0]
 					modified += tup[1]
 
+		if not simulateOnly:
+ 			if sp_showResult is not None:
+				blockingCallFromMainThread(sp_showResult)
+
 		return (len(timers), new, modified, timers, conflicting, similars)
 
 # Supporting functions
@@ -756,11 +765,8 @@ class AutoTimer:
 		del remove
 
 	def modifyTimer(self, timer, name, shortdesc, begin, end, serviceref, eit=None):
-		# Only update the name and description if we got a "new" one
-		if len(timer.name) < len(name):
-			timer.name = name
-		if len(timer.description) < len(shortdesc):
-			timer.description = shortdesc
+		timer.name = name
+		timer.description = shortdesc
 		timer.begin = int(begin)
 		timer.end = int(end)
 		timer.service_ref = ServiceReference(serviceref)

--- a/autotimer/src/Logger.py
+++ b/autotimer/src/Logger.py
@@ -32,29 +32,29 @@ logger = None
 def initLog():
 	global logger
 	logger = logger or logging.getLogger("AT")
-	logger.setLevel(logging.WARNING)
+	logger.setLevel(logging.DEBUG)
 
 	logger.handlers = [] 
 
 	if config.plugins.autotimer.log_shell.value:
 		shandler = logging.StreamHandler(sys.stdout)
-		shandler.setLevel(logging.INFO)
+		shandler.setLevel(logging.DEBUG)
 
 		sformatter = logging.Formatter('%(name)s %(levelname)s - %(message)s')
 		shandler.setFormatter(sformatter)
 
 		logger.addHandler(shandler)
-		logger.setLevel(logging.INFO)
+		logger.setLevel(logging.DEBUG)
 		
 	if config.plugins.autotimer.log_write.value:
 		fhandler = logging.FileHandler(config.plugins.autotimer.log_file.value)
-		fhandler.setLevel(logging.INFO)
+		fhandler.setLevel(logging.DEBUG)
 
 		fformatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 		fhandler.setFormatter(fformatter)
 
 		logger.addHandler(fhandler)
-		logger.setLevel(logging.INFO)
+		logger.setLevel(logging.DEBUG)
 
 def shutdownLog():
 	global logger

--- a/autotimer/src/plugin.py
+++ b/autotimer/src/plugin.py
@@ -32,7 +32,7 @@ from AutoTimer import AutoTimer
 autotimer = AutoTimer()
 autopoller = None
 
-AUTOTIMER_VERSION = "4.0.9"
+AUTOTIMER_VERSION = "4.1.2"
 
 #pragma mark - Help
 try:


### PR DESCRIPTION
-Changed default log level to debug
-Show SeriesPlugin result after all autotimers are handled and if
simulateOnly is not set
-Modify timer should edit all information
-Call modify timer only if we got information from seriespugin or if
label series is disabled
-Pushed version to 4.1.2