### PR TITLE
Forgotten removal by make.am causes configure error.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,6 @@ SUBDIRS = \
 	shoutcast \
 	showclock \
 	simplerss \
-	startuptostandby \
 	svdrp \
 	systemtime \
 	tageditor \


### PR DESCRIPTION
	modified:   Makefile.am