### PR TITLE
[blindsan] fix BSOD when open plugin and show error message

### DIFF
--- a/blindscan/po/blindscan.pot
+++ b/blindscan/po/blindscan.pot
@@ -452,3 +452,5 @@ msgstr ""
 msgid "\nYou must use the power adapter."
 msgstr ""
 
+msgid "Step %d %d:%02d min"
+msgstr ""

--- a/blindscan/po/ru.po
+++ b/blindscan/po/ru.po
@@ -487,3 +487,6 @@ msgstr ""
 
 msgid "\nYou must use the power adapter."
 msgstr "\nВозможно надо использовать адаптер питания."
+
+msgid "Step %d %d:%02d min"
+msgstr "Шаг %d %d:%02d мин"

--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -171,7 +171,7 @@ class Blindscan(ConfigListScreen, Screen):
 			self["green"] = Label(_("Start scan"))
 			self["blue"] = Label("")
 			self["introduction"] = Label("")
-			self.createSetup()
+			self.createSetup(True)
 			self.keyBlue()
 		else :
 			self["actions"] = ActionMap(["ColorActions", "SetupActions", 'DirectionActions'],
@@ -346,7 +346,7 @@ class Blindscan(ConfigListScreen, Screen):
 					if hasattr(self.session, 'pip'):
 						del self.session.pip
 					self.openFrontend()
-		if self.frontend == None :
+		if self.frontend == None:
 			text = _("Sorry, this tuner is in use.")
 			if self.session.nav.getRecordings():
 				text += "\n"
@@ -468,7 +468,7 @@ class Blindscan(ConfigListScreen, Screen):
 			index = index + 1
 		return -1
 
-	def createSetup(self):
+	def createSetup(self, first_start=False):
 		self.list = []
 		self.multiscanlist = []
 		if self.scan_nims == []:
@@ -512,7 +512,12 @@ class Blindscan(ConfigListScreen, Screen):
 				self.list.append(getConfigListEntry(_("Only free scan"), self.scan_onlyfree,_('If you select "yes" the scan will only save channels that are not encrypted; "no" will find encrypted and non-encrypted channels')))
 			self["config"].list = self.list
 			self["config"].l.setList(self.list)
-			self.startDishMovingIfRotorSat()
+			if first_start:
+				self.firstTimer = eTimer()
+				self.firstTimer.callback.append(self.startDishMovingIfRotorSat)
+				self.firstTimer.start(1000, True)
+			else:
+				self.startDishMovingIfRotorSat()
 
 	def newConfig(self):
 		cur = self["config"].getCurrent()

--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -851,8 +851,8 @@ class Blindscan(ConfigListScreen, Screen):
 		elif self.Sundtek_pol in (0, 2) and (pol == eDVBFrontendParametersSatellite.Polarisation_Horizontal or pol == eDVBFrontendParametersSatellite.Polarisation_CircularLeft):
 			add_tp = True
 		if add_tp:
-			freq = (int(data[1]) + self.offset) / 1000
-			symbolrate = int(data[2])
+			freq = (int(data[2]) + self.offset) / 1000
+			symbolrate = int(data[3])
 			if freq >= self.blindscan_start_frequency.value and freq <= self.blindscan_stop_frequency.value and symbolrate >= self.blindscan_start_symbol.value * 1000 and symbolrate <= self.blindscan_stop_symbol.value * 1000:
 				add_tp = True
 			else:
@@ -905,17 +905,23 @@ class Blindscan(ConfigListScreen, Screen):
 							self.offset = 9750000
 				if len(data) >= 6 and data[0] == 'OK' and self.Sundtek_pol != "" and self.offset and self.dataSundtekIsGood(data):
 					parm = eDVBFrontendParametersSatellite()
+					sys = { "DVB-S" : parm.System_DVB_S,
+						"DVB-S2" : parm.System_DVB_S2}
+					qam = { "QPSK" : parm.Modulation_QPSK,
+						"8PSK" : parm.Modulation_8PSK,
+						"16APSK" : parm.Modulation_16APSK,
+						"32APSK" : parm.Modulation_32APSK}
 					parm.orbital_position = self.orb_position
 					parm.polarisation = self.Sundtek_pol
-					frequency = ((int(data[1]) + self.offset) / 1000) * 1000
+					frequency = ((int(data[2]) + self.offset) / 1000) * 1000
 					parm.frequency = frequency
-					symbol_rate = int(data[2]) * 1000
+					symbol_rate = int(data[3]) * 1000
 					parm.symbol_rate = symbol_rate
-					parm.system = parm.System_DVB_S
+					parm.system = sys[data[1]]
 					parm.inversion = parm.Inversion_Off
 					parm.pilot = parm.Pilot_Off
 					parm.fec = parm.FEC_Auto
-					parm.modulation = parm.Modulation_QPSK
+					parm.modulation = qam[data[4]]
 					parm.rolloff = parm.RollOff_alpha_0_35
 					self.tmp_tplist.append(parm)
 			elif len(data) >= 10 and self.dataIsGood(data):
@@ -995,19 +1001,11 @@ class Blindscan(ConfigListScreen, Screen):
 							self.offset = 10600000
 						elif self.Sundtek_band == "low":
 							self.offset = 9750000
-				if len(data) >= 6 and data[0] == 'OK' and self.Sundtek_pol and self.offset:
-					tmpstr = data[1].isdigit() and "%s" % ((int(data[1]) + self.offset) / 1000) or data[1]
-					tmpstr += "%s SR: %s" % (self.Sundtek_pol, data[2])
 					self.tp_found.append(str)
-			#elif len(data) >= 10 and data[0] == 'OK':
-			#	tmpstr = data[2].isdigit() and "%s" % (int(data[2]) / 1000.) or data[2]
-			#	tmpstr += " %s " %data[1]
-			#	tmpstr += data[3].isdigit() and "%s" % (int(data[3]) / 1000.) or data[3]
-			#	self.tp_found.append(str)
-				seconds_done = int(time() - self.start_time)
-				tmpstr += '\n'
-				tmpstr += _("%d transponders found at %d:%02d min") %(len(self.tp_found),seconds_done / 60, seconds_done % 60)
-				self.blindscan_session["text"].setText(self.tmpstr + tmpstr)
+					seconds_done = int(time() - self.start_time)
+					tmpstr += '\n'
+					tmpstr += _("Step %d %d:%02d min") %(len(self.tp_found),seconds_done / 60, seconds_done % 60)
+					self.blindscan_session["text"].setText(self.tmpstr + tmpstr)
 
 	def blindscanSessionNone(self, *val):
 		import time


### PR DESCRIPTION
<  1027.299>   File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/Blindscan/plugin.py",
line 1359, in startDishMovingIfRotorSat
<  1027.302>     if not
self.prepareFrontend():
<  1027.302>   File
"/usr/lib/enigma2/python/Plugins/SystemPlugins/Blindscan/plugin.py",
line 354, in prepareFrontend
<  1027.303>
self.session.open(MessageBox, text, MessageBox.TYPE_ERROR)
<  1027.303>
File "/usr/lib/enigma2/python/mytest.py", line 285, in open
<  1027.303>
raise RuntimeError("modal open are allowed only from a screen which is
modal!")
<  1027.304> RuntimeError: modal open are allowed only from a
screen which is modal!