### PR TITLE
Autoresolution - do not write configfile for every entry in config li…

### DIFF
--- a/autoresolution/src/plugin.py
+++ b/autoresolution/src/plugin.py
@@ -375,7 +375,7 @@ class AutoResSetupMenu(Screen, ConfigListScreen):
 	def apply(self):
 		for x in self["config"].list:
 			x[1].save()
-			configfile.save()
+		configfile.save()
 		self.close()
 
 	def keyLeft(self):


### PR DESCRIPTION
…st, only save it once. This speeds up closing of plugin. There is no need to save configfile 20 times.