### PR TITLE
Revert option getStatusParseEPGrunning

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -205,7 +205,8 @@ class AutoTimer:
 		file.close()
 
 	def getStatusParseEPGrunning(self):
-		return self.isParseRunning
+		#return self.isParseRunning
+		return False
 
 # Manage List
 	def add(self, timer):
@@ -767,8 +768,8 @@ class AutoTimer:
 			return (0, 0, 0, [], [], [])
 
 		if self.isParseRunning:
-			doLog("[AutoTimer] parse EPG it is already running, return zero")
-			return (0, 0, 0, [], [], [])
+			doLog("[AutoTimer] parse EPG it is already running, return zero, test only")
+			#return (0, 0, 0, [], [], [])
 		else:
 			self.isParseRunning = True
 


### PR DESCRIPTION
This requires additional inquiry
2016-07-26 10:17:08,436 - INFO - [AutoTimer] Start reload timers list
after search
2016-07-26 13:50:36,413 - INFO - AutoTimer Version: 4.1.2
2016-07-26 13:50:36,435 - INFO - [AutoTimer] parse EPG it is already
running, return zero
2016-07-27 13:50:34,482 - INFO - AutoTimer Version: 4.1.2
2016-07-27 13:50:34,493 - INFO - [AutoTimer] parse EPG it is already
running, return zero
2016-07-28 13:50:32,526 - INFO - AutoTimer Version: 4.1.2
2016-07-28 13:50:32,540 - INFO - [AutoTimer] parse EPG it is already
running, return zero
2016-07-29 13:50:30,565 - INFO - AutoTimer Version: 4.1.2
2016-07-29 13:50:30,576 - INFO - [AutoTimer] parse EPG it is already
running, return zero
2016-07-30 13:50:29,600 - INFO - AutoTimer Version: 4.1.2
2016-07-30 13:50:29,613 - INFO - [AutoTimer] parse EPG it is already
running, return zero
2016-07-31 00:37:07,279 - INFO - [AutoTimer] No changes in
configuration, won't parse