### PR TITLE
[blindscan]  compatibility for multistream

### DIFF
--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -967,6 +967,12 @@ class Blindscan(ConfigListScreen, Screen):
 					parm.fec = parm.FEC_Auto
 					parm.modulation = qam[data[4]]
 					parm.rolloff = parm.RollOff_alpha_0_35
+					try:
+						parm.pls_mode = eDVBFrontendParametersSatellite.PLS_Root
+						parm.is_id = -1
+						parm.pls_code = 1
+					except:
+						pass
 					self.tmp_tplist.append(parm)
 			elif len(data) >= 10 and self.dataIsGood(data):
 				if data[0] == 'OK':
@@ -1012,6 +1018,12 @@ class Blindscan(ConfigListScreen, Screen):
 					parm.fec = fec[data[7]]
 					parm.modulation = qam[data[8]]
 					parm.rolloff = roll[data[9]]
+					try:
+						parm.pls_mode = eDVBFrontendParametersSatellite.PLS_Root
+						parm.is_id = -1
+						parm.pls_code = 1
+					except:
+						pass
 					self.tmp_tplist.append(parm)
 		self.blindscan_session.close(True)
 		self.blindscan_session = None
@@ -1153,6 +1165,10 @@ class Blindscan(ConfigListScreen, Screen):
 				parm.modulation = x[6]
 				parm.rolloff = x[8]
 				parm.pilot = x[9]
+				if len(x) > 12:
+					parm.is_id = x[10]
+					parm.pls_mode = x[11]
+					parm.pls_code = x[12]
 				tlist.append(parm)
 		return tlist
 


### PR DESCRIPTION
Add some compatibility for images with multistream so channels are
correctly saved in lamedb.

This commit does not imply the blindscan plugin will be able to decipher
PLS codes, etc.

thanks Huevos