### PR TITLE
[autotimer] fix create autotimer.log

### DIFF
--- a/autotimer/src/Logger.py
+++ b/autotimer/src/Logger.py
@@ -47,14 +47,22 @@ def initLog():
 		logger.setLevel(logging.DEBUG)
 		
 	if config.plugins.autotimer.log_write.value:
-		fhandler = logging.FileHandler(config.plugins.autotimer.log_file.value)
-		fhandler.setLevel(logging.DEBUG)
+		try:
+			try:
+				fhandler = logging.FileHandler(config.plugins.autotimer.log_file.value)
+			except:
+				config.plugins.autotimer.log_file.value = "/tmp/autotimer.log"
+				config.plugins.autotimer.log_file.save()
+			fhandler = logging.FileHandler(config.plugins.autotimer.log_file.value)
+			fhandler.setLevel(logging.DEBUG)
 
-		fformatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-		fhandler.setFormatter(fformatter)
+			fformatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+			fhandler.setFormatter(fformatter)
 
-		logger.addHandler(fhandler)
-		logger.setLevel(logging.DEBUG)
+			logger.addHandler(fhandler)
+			logger.setLevel(logging.DEBUG)
+		except:
+			logger = None
 
 def shutdownLog():
 	global logger

--- a/autotimer/src/__init__.py
+++ b/autotimer/src/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from Components.Language import language
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS, SCOPE_LANGUAGE
-from os import environ as os_environ
 import gettext
 
 # Config
@@ -81,8 +80,9 @@ config.plugins.autotimer.style_autotimerslist = ConfigSelection(choices=[
 
 config.plugins.autotimer.log_shell = ConfigYesNo(default = False)
 config.plugins.autotimer.log_write = ConfigYesNo(default = False)
-config.plugins.autotimer.log_file  = ConfigText(default = "/tmp/autotimer.log", fixed_size = False)
-if config.plugins.autotimer.log_file.value == "":
+config.plugins.autotimer.log_file = ConfigText(default = "/tmp/autotimer.log", fixed_size = False)
+val = config.plugins.autotimer.log_file.value
+if not val or not val.endswith("autotimer.log"):
 	config.plugins.autotimer.log_file.value = "/tmp/autotimer.log"
 	config.plugins.autotimer.log_file.save()
 


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Plugins/Extensions/AutoTimer/Logger.py",
line 98, in <module>
    initLog()
  File
"/usr/lib/enigma2/python/Plugins/Extensions/AutoTimer/Logger.py", line
50, in initLog
    fhandler =
logging.FileHandler(config.plugins.autotimer.log_file.value)
  File
"/usr/lib/python2.7/logging/__init__.py", line 897, in __init__

File "/usr/lib/python2.7/logging/__init__.py", line 916, in _open

IOError: [Errno 2] No such file or directory: '/hdd/logs/autotimer.log'