### PR TITLE
[autotimer] auto resolve conflict offset time begin/end (30 sec)

### DIFF
--- a/autotimer/src/plugin.py
+++ b/autotimer/src/plugin.py
@@ -32,7 +32,7 @@ from AutoTimer import AutoTimer
 autotimer = AutoTimer()
 autopoller = None
 
-AUTOTIMER_VERSION = "4.1.2"
+AUTOTIMER_VERSION = "4.1.5"
 
 #pragma mark - Help
 try:


### PR DESCRIPTION
example - for sake of simplicity, usage is on a single tuner receiver ,
no overlaps in the timers
Timer A = 19:00 to 19:30 service 1
Timer B = 19:30 to 20:00 service 2
The above will always result in a clash because one ends at 19:30 and
the other also starts at 19:30
End 19:30:00.000 and start at 19:30:30.000 should work, but that is not
currently possible.

-update version
-small cosmetic