### PR TITLE
[AutoResolution] fix bug 720p50 mode

### DIFF
--- a/autoresolution/src/plugin.py
+++ b/autoresolution/src/plugin.py
@@ -318,7 +318,7 @@ class AutoRes(Screen):
 			return
 		if usable:
 			mode = self.lastmode
-			if "p24" in mode or "p25" in mode or "p30" in mode or (self.extra_mode1080p50 and "1080p50" in mode) or (self.extra_mode1080p60 and "1080p60" in mode) or (self.extra_mode720p60 and "720p60" in mode):
+			if "p24" in mode or "p25" in mode or "p30" in mode or (self.extra_mode1080p50 and "1080p50" in mode) or (self.extra_mode1080p60 and "1080p60" in mode) or (self.extra_mode720p60 and "720p60" in mode) or "720p50" in mode:
 				try:
 					v = open('/proc/stb/video/videomode' , "w")
 					v.write("%s\n" % mode)


### PR DESCRIPTION
error log:

"/usr/lib/enigma2/python/Plugins/SystemPlugins/AutoResolution/plugin.py",
line 356, in setMode
    rate =config.av.videorate[mode].value
KeyError: '720p50'