### PR TITLE
Improve .po files update for plugins

### DIFF
--- a/Rules-po.mak
+++ b/Rules-po.mak
@@ -8,7 +8,8 @@ LANGPO = $(LANGS:=.po)
 if UPDATE_PO
 # the TRANSLATORS: allows putting translation comments before the to-be-translated line.
 $(PLUGIN)-py.pot: $(srcdir)/../src/*.py
-	$(XGETTEXT) -L python --from-code=UTF-8 --add-comments="TRANSLATORS:" -d $(PLUGIN) -s -o $@ $^
+	$(XGETTEXT) -L python --from-code=UTF-8 --add-comments="TRANSLATORS:" -d $(PLUGIN) -s -o $@ $^; \
+	$(SED) --in-place $@ --expression=s/CHARSET/UTF-8/; 
 
 $(PLUGIN)-xml.pot: $(top_srcdir)/xml2po.py $(srcdir)/../src/*.xml
 	$(PYTHON) $^ > $@
@@ -19,6 +20,7 @@ $(PLUGIN).pot: $(PLUGIN)-py.pot $(PLUGIN)-xml.pot
 %.po: $(PLUGIN).pot
 	if [ -f $@ ]; then \
 		$(MSGMERGE) --backup=none --no-location -s -N -U $@ $< && touch $@; \
+		$(MSGATTRIB) --no-wrap --no-obsolete $@ -o $@; \
 	else \
 		$(MSGINIT) -l $@ -o $@ -i $< --no-translator; \
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -39,8 +39,9 @@ if test "$with_po" = "yes"; then
 	AC_PATH_PROG(MSGINIT, msginit)
 	AC_PATH_PROG(MSGMERGE, msgmerge)
 	AC_PATH_PROG(MSGUNIQ, msguniq)
+	AC_PATH_PROG(MSGATTRIB, msgattrib)
 	AC_PATH_PROG(XGETTEXT, xgettext)
-	if test -z "$MSGINIT" -o -z "$MSGMERGE" -o -z "$MSGUNIQ" -o -z "$XGETTEXT"; then
+	if test -z "$MSGINIT" -o -z "$MSGMERGE" -o -z "$MSGUNIQ" -o -z "$MSGATTRIB" -o -z "$XGETTEXT"; then
 		AC_MSG_ERROR([Could not find required gettext tools])
 	fi
 fi


### PR DESCRIPTION
This change create .po files for plugins that:
- is also --no-wrap
- delete the obsolete strings with --no-obsolete
- include the replacement of the CHARSET into UTF-8 for the *-py.pot file

Pr2