### PR TITLE
blindscan: detect all edision models

### DIFF
--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -47,7 +47,7 @@ elif fileExists("/proc/stb/info/boxtype") and not fileExists("/proc/stb/info/hwm
 			BOX_MODEL = "formuler"
 		elif BOX_NAME.startswith('hd'):
 			BOX_MODEL = "hd"
-		elif BOX_NAME.startswith('osm'):
+		elif BOX_NAME.startswith('os'):
 			BOX_MODEL = "edision"
 		else:
 			BOX_MODEL = "useBoxtype"


### PR DESCRIPTION
All edision models start with os, so simplify check.