### PR TITLE
blindscan: map S2X to S2 system

### DIFF
--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -994,7 +994,8 @@ class Blindscan(ConfigListScreen, Screen):
 				if data[0] == 'OK':
 					parm = eDVBFrontendParametersSatellite()
 					sys = { "DVB-S" : parm.System_DVB_S,
-						"DVB-S2" : parm.System_DVB_S2}
+						"DVB-S2" : parm.System_DVB_S2,
+						"DVB-S2X" : parm.System_DVB_S2}
 					qam = { "QPSK" : parm.Modulation_QPSK,
 						"8PSK" : parm.Modulation_8PSK,
 						"16APSK" : parm.Modulation_16APSK,


### PR DESCRIPTION
The data returned from vuzero4k blindscan utility can contain
delivery system S2X. Add mapping to delivery system S2.

This commit will fix the following error:
sys[data[4]]
KeyError: 'DVB-S2X'

Data returned by utility:
[Blind scan] cnt : 10 , data : ['OK', 'VERTICAL', '10799296', '34001000', 'DVB-S2X', 'INVERSION_AUTO', 'PILOT_OFF', 'FEC_11_15', '32APSK', 'ROLLOFF_35']

Please note that FEC_11_15 is handled as AUTO by a previous commit.