### PR TITLE
Allows low symbol rate transponders to have a smaller frequency toler…

### DIFF
--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -1331,9 +1331,10 @@ class Blindscan(ConfigListScreen, Screen):
 		multiplier = 1000
 		x = 0
 		for t in tplist:
+			freqSyncTol = min(tolerance, max(1, int(t.symbol_rate/1000000))) # sets frequency tolerance between 1 and 5 for low symbol rate transponders. Transponders with SR above 5000 are not affected.
 			for k in knowntp:
 				if (t.polarisation % 2) == (k.polarisation % 2) and \
-					abs(t.frequency - k.frequency) < (tolerance*multiplier) and \
+					abs(t.frequency - k.frequency) < (freqSyncTol*multiplier) and \
 					abs(t.symbol_rate - k.symbol_rate) < (tolerance*multiplier) and \
 					t.is_id == k.is_id and t.pls_code == k.pls_code and t.pls_mode == k.pls_mode:
 					tplist[x] = k
@@ -1356,9 +1357,10 @@ class Blindscan(ConfigListScreen, Screen):
 		x = 0
 		isnt_known = True
 		for t in tplist:
+			freqSyncTol = min(tolerance, max(1, int(t.symbol_rate/1000000))) # sets frequency tolerance between 1 and 5 for low symbol rate transponders. Transponders with SR above 5000 are not affected.
 			for k in knowntp:
 				if (t.polarisation % 2) == (k.polarisation % 2) and \
-					abs(t.frequency - k.frequency) < (tolerance*multiplier) and \
+					abs(t.frequency - k.frequency) < (freqSyncTol*multiplier) and \
 					abs(t.symbol_rate - k.symbol_rate) < (tolerance*multiplier):
 					isnt_known = False
 					#break


### PR DESCRIPTION
…ance when syncronising with known transponders.

This allows transponders with low symbol rates (5000 and below)  not to be recognied as duplicates/phantoms when they are very tightly grouped. As symbol rate is directly related to how much band spectrum the transponder occupies it can be used in this role.