### PR TITLE
Blindscan: Please avoid hard coded values

### DIFF
--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -1561,7 +1561,7 @@ class Blindscan(ConfigListScreen, Screen):
 				self.is_c_band_scan = True
 				return True
 			elif lof == "user_defined" and currLnb.lofl.value == currLnb.lofh.value and currLnb.lofl.value > 5000 and currLnb.lofl.value < 30000:
-				if currLnb.lofl.value == 10750 and currLnb.lofh.value == 10750 and cur_orb_pos in (360, 560):
+				if currLnb.lofl.value == self.circular_lnb_lo_freq and currLnb.lofh.value == self.circular_lnb_lo_freq and cur_orb_pos in (360, 560): # "circular_lnb" legacy support hack. For people using a "circular" LNB but that have their tuner set up as "user defined".
 					self.user_defined_lnb_lo_freq = self.circular_lnb_lo_freq
 					self.suggestedPolarisation = _("circular left/right")
 				else:


### PR DESCRIPTION
A lot work has been put in to the plugin over the last few days to use a coding style that eliminates these hard coded values. Please do not start re-introducing them.