### PR TITLE
[AutoTimer] version 4.6 - fix incorrect eit

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -647,6 +647,9 @@ class AutoTimer:
 
 				changed = newEntry.begin != begin or newEntry.end != end or newEntry.name != name
 				if allow_modify:
+					if oldExists and newEntry.service_ref == ServiceReference(serviceref) and newEntry.eit == eit and newEntry.name == name and newEntry.begin < begin and newEntry.end < end and (begin - newEntry.end) <= 600:
+						begin = newEntry.begin
+						doLog("[AutoTimer] This same eit and different times end - update only end")
 					if self.modifyTimer(newEntry, name, shortdesc, begin, end, serviceref, eit, base_timer=timer):
 						msg = "[AutoTimer] AutoTimer modified timer: %s ." % (newEntry.name)
 						doLog(msg)

--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -647,7 +647,7 @@ class AutoTimer:
 
 				changed = newEntry.begin != begin or newEntry.end != end or newEntry.name != name
 				if allow_modify:
-					if oldExists and newEntry.service_ref == ServiceReference(serviceref) and newEntry.eit == eit and newEntry.name == name and newEntry.begin < begin and newEntry.end < end and (begin - newEntry.end) <= 600:
+					if oldExists and newEntry.service_ref == ServiceReference(serviceref) and newEntry.eit == eit and newEntry.name == name and newEntry.begin < begin and newEntry.end < end and (0 < begin - newEntry.end <= 600):
 						begin = newEntry.begin
 						doLog("[AutoTimer] This same eit and different times end - update only end")
 					if self.modifyTimer(newEntry, name, shortdesc, begin, end, serviceref, eit, base_timer=timer):

--- a/autotimer/src/plugin.py
+++ b/autotimer/src/plugin.py
@@ -38,7 +38,7 @@ from AutoTimer import AutoTimer
 autotimer = AutoTimer()
 autopoller = None
 
-AUTOTIMER_VERSION = "4.5"
+AUTOTIMER_VERSION = "4.6"
 
 try:
 	from Plugins.SystemPlugins.MPHelp import registerHelp, XMLHelpReader


### PR DESCRIPTION
-when eit it same(wrong internet EPG) and start/end timers different and
the difference is less than 10 minutes. That is the second part of the
recording.