### PR TITLE
[blindscan] add text for model reciever

### DIFF
--- a/blindscan/src/dmmBlindScan.py
+++ b/blindscan/src/dmmBlindScan.py
@@ -406,7 +406,7 @@ class SatelliteTransponderSearchSupport:
 		tuner_no = -1
 
 		self.auto_scan = nimmanager.nim_slots[nim_idx].supportsBlindScan() or tunername.startswith('Si216')
-		if self.auto_scan or tunername == "Alps BSBE1 C01A/D01A." or (tunername.startswith("BCM45") and tunername != "BCM4501"):
+		if self.auto_scan or tunername == "Alps BSBE1 C01A/D01A." or (tunername != "BCM4501" and "BCM45" in tunername):
 			(self.channel, self.frontend) = self.tryGetRawFrontend(nim_idx, False, False)
 			if not self.frontend:
 				self.session.nav.stopService()
@@ -789,7 +789,7 @@ class DmmBlindscan(ConfigListScreen, Screen, TransponderSearchSupport, Satellite
 		self.session.nav.playService(self.session.postScanService)
 		for x in self["config"].list:
 			x[1].cancel()
-		self.close()
+		self.close(False)
 
 	def startScanCallback(self, answer=True):
 		if answer:

--- a/blindscan/src/plugin.py
+++ b/blindscan/src/plugin.py
@@ -49,8 +49,8 @@ def getMisPlsValue(d, idx, defaultValue):
 	except:
 		return defaultValue
 
-BOX_MODEL = "none"
-BOX_NAME = ""
+BOX_MODEL = "all"
+BOX_NAME = "none"
 if fileExists("/proc/stb/info/vumodel") and not fileExists("/proc/stb/info/hwmodel") and not fileExists("/proc/stb/info/boxtype"):
 	try:
 		l = open("/proc/stb/info/vumodel")
@@ -241,7 +241,7 @@ class Blindscan(ConfigListScreen, Screen):
 		"""
 	def __init__(self, session):
 		Screen.__init__(self, session)
-		self.setup_title = _("Blind scan for DVB-S2 tuners")
+		self.setup_title = _("Blind scan for DVB-S2 tuners") + ":" + BOX_NAME + "/" + BOX_MODEL
 		Screen.setTitle(self, _(self.setup_title))
 		self.skinName = "Blindscan"
 		self.session.postScanService = self.session.nav.getCurrentlyPlayingServiceOrGroup()


### PR DESCRIPTION
-fix close DMM mode
Traceback (most recent call last):
  File
"/usr/lib/enigma2/python/mytest.py", line 210, in processDelay

callback(*retval)
  File
"/usr/lib/enigma2/python/Tools/BoundFunction.py", line 9, in
__call__
TypeError: BlindscanCallback() takes exactly 2 arguments (1
given)
- fix tuner name for ' BCM45308X'