### PR TITLE
[autotimer] 4.6.2 - attempt to solve memory problems

### DIFF
--- a/autotimer/src/AutoPoller.py
+++ b/autotimer/src/AutoPoller.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from . import _
 # Core functionality
-from enigma import eTimer, ePythonMessagePump
+from enigma import eTimer, ePythonMessagePump, eConsoleAppContainer
 
 # Config
 from Components.config import config
@@ -93,6 +93,8 @@ class AutoPollerThread(Thread):
 		self.__timer.callback.remove(self.timeout)
 
 	def run(self):
+		if config.plugins.autotimer.clear_memory.value:
+			self.clearMemory()
 		sem = self.__semaphore
 		queue = self.__queue
 		pump = self.__pump
@@ -141,6 +143,10 @@ class AutoPollerThread(Thread):
 				traceback.print_exc(file=sys.stdout)
 			#Keep that eTimer in the mainThread
 			reactor.callFromThread(timer.startLongTimer, config.plugins.autotimer.interval.value*3600)
+
+	def clearMemory(self):
+		eConsoleAppContainer().execute("sync")
+		open("/proc/sys/vm/drop_caches", "w").write("3")
 
 class AutoPoller:
 	"""Manages actual thread which does the polling. Used for convenience."""

--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -379,7 +379,7 @@ class AutoTimer:
 
 		else:
 			# Search EPG, default to empty list
-			epgmatches = epgcache.search( ('RITBDSE', 3000, typeMap[timer.searchType], match, caseMap[timer.searchCase]) ) or []
+			epgmatches = epgcache.search( ('RITBDSE', int(config.plugins.autotimer.max_search_events_match.value), typeMap[timer.searchType], match, caseMap[timer.searchCase]) ) or []
 
 		# Sort list of tuples by begin time 'B'
 		epgmatches.sort(key=itemgetter(3))
@@ -407,11 +407,11 @@ class AutoTimer:
 				skipped.append((name, begin, end, str(serviceref), timer.name, getLog()))
 				continue
 			# Try to determine real service (we always choose the last one)
-			n = evt.getNumOfLinkageServices()
-			if n > 0:
-				i = evt.getLinkageService(eserviceref, n-1)
-				serviceref = i.toString()
-				doLog("[AutoTimer] Serviceref2 %s" % (str(serviceref)))
+			#n = evt.getNumOfLinkageServices()
+			#if n > 0:
+			#	i = evt.getLinkageService(eserviceref, n-1)
+			#	serviceref = i.toString()
+			#	doLog("[AutoTimer] Serviceref2 %s" % (str(serviceref)))
 
 
 			# If event starts in less than 60 seconds skip it

--- a/autotimer/src/AutoTimerSettings.py
+++ b/autotimer/src/AutoTimerSettings.py
@@ -62,6 +62,8 @@ class AutoTimerSettings(Screen, ConfigListScreen):
 			getConfigListEntry(_("Delay after editing (in sec)"), config.plugins.autotimer.editdelay, _("This is the delay in seconds that the AutoTimer will wait after editing the AutoTimers.")),
 			getConfigListEntry(_("Poll Interval (in h)"), config.plugins.autotimer.interval, _("This is the delay in hours that the AutoTimer will wait after a search to search the EPG again.")),
 			getConfigListEntry(_("Timeout (in min)"), config.plugins.autotimer.timeout, _("This is the duration in minutes that the AutoTimer is allowed to run.")),
+			getConfigListEntry(_("Max. match search events"), config.plugins.autotimer.max_search_events_match, _("If your receiver has a small amount of memory, use mode 'Standard (1000 events)' or 'Advanced (2000 events)'.")),
+			getConfigListEntry(_("Clear memory before auto run"), config.plugins.autotimer.clear_memory, _("If your receiver has a small amount of memory, clear memory before poll AutoTimer run.")),
 			getConfigListEntry(_("Only add timer for next x days"), config.plugins.autotimer.maxdaysinfuture, _("You can control for how many days in the future timers are added. Set this to 0 to disable this feature.")),
 			getConfigListEntry(_("Show in extension menu"), config.plugins.autotimer.show_in_extensionsmenu, _("Enable this to be able to access the AutoTimer Overview from within the extension menu.")),
 			getConfigListEntry(_("Show in event menu"), config.plugins.autotimer.show_in_furtheroptionsmenu, _("Enable this to add item for create the AutoTimer into event menu (needs restart GUI).")),

--- a/autotimer/src/__init__.py
+++ b/autotimer/src/__init__.py
@@ -100,7 +100,13 @@ config.plugins.autotimer.searchlog_path = ConfigSelection(choices=[
 	], default="?likeATlog?"
 )
 config.plugins.autotimer.searchlog_max = ConfigSelectionNumber(5, 20, 1, default = 5)
-
+config.plugins.autotimer.max_search_events_match = ConfigSelection(choices=[
+		("1000", _("Standard (1000 events)")),
+		("2000", _("Advanced (2000 events)")),
+		("3000", _("Full (3000 events)"))
+	], default="1000"
+)
+config.plugins.autotimer.clear_memory = ConfigYesNo(default = False)
 
 try:
 	xrange = xrange

--- a/autotimer/src/plugin.py
+++ b/autotimer/src/plugin.py
@@ -38,7 +38,7 @@ from AutoTimer import AutoTimer
 autotimer = AutoTimer()
 autopoller = None
 
-AUTOTIMER_VERSION = "4.6.1"
+AUTOTIMER_VERSION = "4.6.2"
 
 try:
 	from Plugins.SystemPlugins.MPHelp import registerHelp, XMLHelpReader


### PR DESCRIPTION
-add option "Clear memory before auto run"
-add option "Max. match search events" (1000/2000/3000 events)
-delete old code for subservices