### PR TITLE
[partnerbox] fix init first remote config

### DIFF
--- a/partnerbox/src/RemoteTimerEntry.py
+++ b/partnerbox/src/RemoteTimerEntry.py
@@ -343,6 +343,7 @@ def RemoteTimerConfig(self):
 	else:
 		default = "0"
 	self.timerentry_remote = ConfigSelection(default = default, choices = self.entryguilist)
+	baseTimercreateConfig(self)
 
 #def getLocationsError(self, error):
 #	RemoteTimercreateConfig(self)


### PR DESCRIPTION
File
"/usr/lib/enigma2/python/Plugins/Extensions/Partnerbox/RemoteTimerEntry.py",
line 315, in RemoteTimer__init__
    RemoteTimernewConfig(self)
  File
"/usr/lib/enigma2/python/Plugins/Extensions/Partnerbox/RemoteTimerEntry.py",
line 402, in RemoteTimernewConfig
    if self["config"].getCurrent() ==
self.timerRemoteEntry:
AttributeError: 'TimerEntry' object has no
attribute 'timerRemoteEntry'