### PR TITLE
[autotimer] fix show in ChannelContextMenu

### DIFF
--- a/autotimer/src/AutoTimerResource.py
+++ b/autotimer/src/AutoTimerResource.py
@@ -262,6 +262,7 @@ class AutoTimerAddXMLAutoTimerResource(AutoTimerBaseResource):
 		req.setHeader('charset', 'UTF-8')
 		xml = req.args.get("xml")
 		if xml:
+			autotimer.readXml() # read current timers to ensure autotimer.timers is populated with current autotimers
 			autotimer.readXmlTimer(xml[0])
 			if config.plugins.autotimer.always_write_config.value:
 				autotimer.writeXml()

--- a/autotimer/src/plugin.py
+++ b/autotimer/src/plugin.py
@@ -292,17 +292,16 @@ def AutoTimerChannelContextMenu__init__(self, session, csel):
 	baseChannelContextMenu__init__(self, session, csel)
 	if csel.mode == MODE_TV:
 		current = csel.getCurrentSelection()
-		current_root = csel.getRoot()
-		current_sel_path = current.getPath()
-		current_sel_flags = current.flags
-		inBouquetRootList = current_root and current_root.getPath().find('FROM BOUQUET "bouquets.') != -1 #FIXME HACK
-		inBouquet = csel.getMutableList() is not None
-		isPlayable = not (current_sel_flags & (eServiceReference.isMarker|eServiceReference.isDirectory))
-		if csel.bouquet_mark_edit == OFF and not csel.movemode:
-			if isPlayable:
-				if config.plugins.autotimer.add_to_channelselection.value:
-					callFunction = self.addtoAutoTimer
-					self["menu"].list.insert(3, ChoiceEntryComponent(text = (_("create AutoTimer for current event"), boundFunction(callFunction,1)), key = "bullet"))
+		if current and current.valid():
+			current_root = csel.getRoot()
+			current_sel_path = current.getPath()
+			current_sel_flags = current.flags
+			inBouquetRootList = current_root and current_root.getPath().find('FROM BOUQUET "bouquets.') != -1 #FIXME HACK
+			inBouquet = csel.getMutableList() is not None
+			isPlayable = not (current_sel_flags & (eServiceReference.isMarker|eServiceReference.isDirectory))
+			if config.plugins.autotimer.add_to_channelselection.value and csel.bouquet_mark_edit == OFF and not csel.movemode and isPlayable:
+				callFunction = self.addtoAutoTimer
+				self["menu"].list.insert(3, ChoiceEntryComponent(text = (_("create AutoTimer for current event"), boundFunction(callFunction,1)), key = "bullet"))
 
 def addtoAutoTimer(self, add):
 	sref = self.csel.servicelist.getCurrent()


### PR DESCRIPTION
- and change by SvenH: read current autotimers first to avoid losing
existing timers when adding new timer from Partnerbox client