### PR TITLE
shoutcast: Replace whitespace by underscore

### DIFF
--- a/shoutcast/src/plugin.py
+++ b/shoutcast/src/plugin.py
@@ -106,6 +106,7 @@ class myHTTPClientFactory(HTTPClientFactory):
 	def __init__(self, url, method=b'GET', postdata=None, headers=None,
 			agent="Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0", timeout=0, cookies=None,
 			followRedirect=1, lastModified=None, etag=None):
+		url = url.replace(" ", "_")
 		HTTPClientFactory.__init__(self, url.encode(), method=method, postdata=postdata,
 		headers=headers, agent=agent, timeout=timeout, cookies=cookies, followRedirect=followRedirect)
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Components/ActionMap.py", line 57, in action
  File "/usr/lib/enigma2/python/Plugins/Extensions/SHOUTcast/plugin.py", line 640, in ok_pressed
  File "/usr/lib/enigma2/python/Plugins/Extensions/SHOUTcast/plugin.py", line 711, in getStationList
  File "/usr/lib/enigma2/python/Plugins/Extensions/SHOUTcast/plugin.py", line 130, in sendUrlCommand
  File "/usr/lib/enigma2/python/Plugins/Extensions/SHOUTcast/plugin.py", line 109, in __init__
  File "/usr/lib/python3.9/site-packages/twisted/web/client.py", line 375, in __init__
  File "/usr/lib/python3.9/site-packages/twisted/web/client.py", line 398, in setURL
  File "/usr/lib/python3.9/site-packages/twisted/web/_newclient.py", line 636, in _ensureValidURI
ValueError: Invalid URI b'http://api.shoutcast.com/station/advancedsearch&f=xml&k=fa1jo93O_raeF0v9&search=Dream Pop'