### PR TITLE
Add linter in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ name: plugins ci
 on:
   push:
     paths-ignore:
+      - 'COPYING'
       - 'README.md'
   pull_request:
     paths-ignore:
+      - 'COPYING'
       - 'README.md'
 
 jobs:
@@ -15,16 +17,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: install python 3.11
+      - name: Install python 3.11
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: install dev packages
+      - name: Install python packages
+        run: |
+          pip install flake8
+      - name: Install dev packages
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get -q update
           sudo apt-get install gettext python3.11-dev
-      - name: build plugins
+      - name: Build plugins
         env:
           CC: "gcc-10"
           CXX: "g++-10"
@@ -33,3 +38,19 @@ jobs:
           ./configure CFLAGS=-I/usr/include/tirpc
           make
           python -O -m compileall .
+      - name: Check code changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: python3
+          list-files: shell
+          filters: |
+            mod:
+              - added|modified: '*.py'
+              - added|modified: '*/src*/*.py'
+      - name: Lint changed code
+        continue-on-error: true
+        if: ${{ steps.filter.outputs.mod == 'true' }}
+        run: |
+          mod_files="${{ steps.filter.outputs.mod_files }}"
+          flake8 --ignore=E126,E127,E128,E501,F821,W191 --show-source --filename=./${mod_files// /,.\/}


### PR DESCRIPTION
To check the quality of the changed code.
Because there are many errors in the existing code, in workflow does not show linter errors as workflow step error, but allows to see problems in the workflow log.

Also add COPYING in ignore files.