### PR TITLE
Improve workflow ci file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,16 @@ on:
     paths-ignore:
       - 'COPYING'
       - 'README.md'
+      - '**.info'
+      - '**.txt'
+      - '*/CONTROL/*'
   pull_request:
     paths-ignore:
       - 'COPYING'
       - 'README.md'
+      - '**.info'
+      - '**.txt'
+      - '*/CONTROL/*'
 
 jobs:
   build:
@@ -27,8 +33,8 @@ jobs:
       - name: Install dev packages
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get -q update
-          sudo apt-get install gettext python3.11-dev
+          sudo apt -q update
+          sudo apt install gettext python3.11-dev
       - name: Build plugins
         env:
           CC: "gcc-10"
@@ -46,10 +52,7 @@ jobs:
           list-files: shell
           filters: |
             mod:
-              - added|modified: '*.py'
-              - added|modified: '*/src*/*.py'
-              - added|modified: '*/src*/*/*.py'
-              - added|modified: '*/src*/*/*/*.py'
+              - added|modified: '**.py'
       - name: Lint changed code
         continue-on-error: true
         if: ${{ steps.filter.outputs.mod == 'true' }}


### PR DESCRIPTION
Add in paths-ignore info and txt files, and CONTROL folder. Change apt-get to apt.
Specifies in filter py files on a single line.