### PR TITLE
[AutoTimer] add sanity check epgcache.lookupEvent

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -397,7 +397,7 @@ class AutoTimer:
 					try:
 						event = epgcache.lookupEvent(lookup) or []
 					except Exception as e:
-						print("[EPGSearch] wrong event", e)
+						print("[AutoTimer] wrong event", e)
 					else:
 						allevents += event
 

--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -464,6 +464,11 @@ class AutoTimer:
 			#	serviceref = i.toString()
 			#	doLog("[AutoTimer] Serviceref2 %s" % serviceref)
 
+			if end < time():
+				doLog("[AutoTimer] Skipping expired timer")
+				skipped.append((name, begin, end, serviceref, timer.name, getLog()))
+				continue
+
 			# If event starts in less than 60 seconds skip it
 			if begin < time() + 60:
 				doLog("[AutoTimer] Skipping an event because it starts in less than 60 seconds")

--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -664,7 +664,7 @@ class AutoTimer:
 					if not rtimer.disabled:
 						if self.checkDoubleTimers(timer, name, rtimer.name, begin, rtimer.begin, end, rtimer.end, serviceref, rtimer.service_ref.ref.toString(), enable_multiple_timer):
 							oldExists = True
-							print("[AutoTimer] We found a timer with same start time, skipping event")
+							doLog("[AutoTimer] We found a timer with same start time, skipping event")
 							break
 						if timer.avoidDuplicateDescription >= 2:
 							if self.checkSimilarity(timer, name, rtimer.name, shortdesc, rtimer.description, extdesc, rtimer.extdesc):


### PR DESCRIPTION
-When single event data from Internet EPG is corrupted.

"SystemError: <built-in function eEPGCache_lookupEvent> returned a result with an error set"

"[AutoTimer] wrong event <built-in function eEPGCache_lookupEvent> returned a result with an error set"

But we keep the rest of the events for searching.