### PR TITLE
lcd4linux: Match InfoBarGenerics channel numbering

### DIFF
--- a/lcd4linux/src/plugin.py
+++ b/lcd4linux/src/plugin.py
@@ -10437,7 +10437,7 @@ def getNumber(actservice):
 						service = servicelist.getNext()
 						if not service.valid():  # check end of list
 							break
-						playable = not (service.flags & mask)
+						playable = not (service.flags & mask) or (service.flags & eServiceReference.isNumberedMarker)
 						if playable:
 							number += 1
 #						L4logE(" ",service.getPath())


### PR DESCRIPTION
Pretty self explanatory, this changes the channel numbering logic used in the lcd4linux plugin to match that of InfoBarGenerics:

https://github.com/OpenPLi/enigma2/blob/6efd0e845e20bf16dcddbe98d3960f043f36fb39/lib/python/Screens/InfoBarGenerics.py#L679

Was a pet peeve of mine so I thought I'd share the fix.