### PR TITLE
lcd4linux: Fix folder selection

### DIFF
--- a/lcd4linux/src/myFileList.py
+++ b/lcd4linux/src/myFileList.py
@@ -207,8 +207,8 @@ class FileList(MenuList):
 		return False if self.getSelection() == "" else self.getSelection()[1]
 
 	def descent(self):
-		if self.getSelection() != "" and self.current_directory is not None:
-			se = self.current_directory if self.current_directory.endswith("/") else os_path.basename(self.current_directory)
+		if self.getSelection() != "":
+			se = (self.current_directory if self.current_directory.endswith("/") else os_path.basename(self.current_directory)) if self.current_directory is not None else ""
 			self.changeDir(self.getSelection()[0], select=se)
 
 	def getFilename(self):


### PR DESCRIPTION
Authored by Stan
https://forums.openpli.org/user/47662-stan/

It addresses a problem with the file/folder selection in the LCD4Linux configuration screens: If you are on top level (storage device list) you're stuck.