### PR TITLE
lcd4linux: Fix Samsung display

### DIFF
--- a/lcd4linux/src/plugin.py
+++ b/lcd4linux/src/plugin.py
@@ -2654,7 +2654,7 @@ def BRI(w1, w2):
 
 def virtBRI(LCD):
 	global AktNight
-	vb = BRI(L4LElist.getBrightness(LCD), LCD)
+	vb = int(BRI(L4LElist.getBrightness(LCD), LCD))
 	if vb < 1:
 		return 0
 	elif vb == 10:


### PR DESCRIPTION
Thanks Stan and Cobus for reporting and testing.

Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Plugins/Extensions/LCD4linux/plugin.py", line 3193, in writeLCD1
    if LCD4linux.LCDType1.value[0] in ["2", "3"] and virtBRI(1) not in [0, 10] and SAVE == True and LCD4linux.MJPEGvirtbri1.value == True:
  File "/usr/lib/enigma2/python/Plugins/Extensions/LCD4linux/plugin.py", line 2658, in virtBRI
    if vb < 1:
TypeError: '<' not supported between instances of 'str' and 'int'