### PR TITLE
shoutcast: Fix crash when recording stream

### DIFF
--- a/shoutcast/src/plugin.py
+++ b/shoutcast/src/plugin.py
@@ -402,7 +402,7 @@ class SHOUTcastWidget(Screen):
 		self["key_red"].setText(_("Record"))
 
 	def streamripperDataAvail(self, data):
-		sData = data.replace('\n', '')
+		sData = data.decode().replace('\n', '')
 		self["console"].setText(sData)
 
 	def stopReloadStationListTimer(self):


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Plugins/Extensions/SHOUTcast/plugin.py", line 405, in streamripperDataAvail
TypeError: a bytes-like object is required, not 'str'