### PR TITLE
[autoresolution"] add option "Use 'seek' for stream/video content"

### DIFF
--- a/autoresolution/po/ru.po
+++ b/autoresolution/po/ru.po
@@ -200,10 +200,13 @@ msgid "default"
 msgstr "дефолт"
 
 msgid "no"
-msgstr ""
+msgstr "нет"
 
 msgid "second"
 msgstr "сек."
 
 msgid "seconds"
 msgstr "сек."
+
+msgid "Use 'seek' for stream/video content"
+msgstr "Использовать 'seek' для стрима/видео"

--- a/autoresolution/src/plugin.py
+++ b/autoresolution/src/plugin.py
@@ -98,6 +98,7 @@ config.plugins.autoresolution.ask_timeout = ConfigSelection(default="20", choice
 config.plugins.autoresolution.manual_resolution_ext_menu = ConfigYesNo(default=False)
 config.plugins.autoresolution.manual_resolution_ask = ConfigYesNo(default=True)
 config.plugins.autoresolution.force_progressive_mode = ConfigYesNo(default=False)
+config.plugins.autoresolution.seek_video_stream_service = ConfigYesNo(default=False)
 
 
 def setDeinterlacer(mode):
@@ -478,7 +479,7 @@ class AutoRes(Screen):
 					v.write("%s\n" % mode)
 					v.close()
 					print("[AutoRes] switching to", mode)
-					if self.video_stream_service:
+					if self.video_stream_service and config.plugins.autoresolution.seek_video_stream_service.value:
 						self.doSeekRelative(2 * 9000)
 				except:
 					print("[AutoRes] failed switching to", mode)
@@ -518,7 +519,7 @@ class AutoRes(Screen):
 				resolutionlabel.show()
 			try:
 				video_hw.setMode(port, mode, rate)
-				if self.video_stream_service:
+				if self.video_stream_service and config.plugins.autoresolution.seek_video_stream_service.value:
 					self.doSeekRelative(2 * 9000)
 			except:
 				print("[AutoRes] Videomode: failed switching to", mode)
@@ -620,7 +621,8 @@ class AutoResSetupMenu(Screen, ConfigListScreen):
 						getConfigListEntry(_("Running in testmode"), config.plugins.autoresolution.testmode),
 						getConfigListEntry(_("Deinterlacer mode for interlaced content"), config.plugins.autoresolution.deinterlacer),
 						getConfigListEntry(_("Deinterlacer mode for progressive content"), config.plugins.autoresolution.deinterlacer_progressive),
-						getConfigListEntry(_("Force set progressive for stream/video content"), config.plugins.autoresolution.force_progressive_mode)
+						getConfigListEntry(_("Force set progressive for stream/video content"), config.plugins.autoresolution.force_progressive_mode),
+						getConfigListEntry(_("Use 'seek' for stream/video content"), config.plugins.autoresolution.seek_video_stream_service)
 					))
 					if SystemInfo["HasHdrType"]:
 						self.list.append(getConfigListEntry(_("Smart HDR type (set 'auto' HDMI HDR type)"), config.plugins.autoresolution.hdmihdrtype))


### PR DESCRIPTION
-In some cases, using 'seek'  leads to sound problems
https://forums.openpli.org/topic/96082-no-sound-on-any-other-resolution-than-2160p-zgemma-h9s/ 
-Disabled by default