### PR TITLE
[epgrefresh] not call refresh twice

### DIFF
--- a/epgrefresh/src/EPGRefreshTimer.py
+++ b/epgrefresh/src/EPGRefreshTimer.py
@@ -141,6 +141,9 @@ class EPGRefreshTimer(timer.Timer):
 		if config.plugins.epgrefresh.lastscan.value < begin and begin < time():
 			tocall()
 
+		if config.plugins.epgrefresh.lastscan.value > begin and begin < time():
+			begin += 86400
+
 		refreshTimer = EPGRefreshTimerEntry(begin, tocall, nocheck=True)
 
 		i = 0


### PR DESCRIPTION
Box in Deep standby

EPGRefresh has set time for refresh, f.eg. between 6:30 to 8:30.

EPGRefresh wake up box well, refresh is finished in 7:10, box goes again in deep standby.

And - when is box manualy wakeup by user in time < 8:30, after wakeup EPGRefresh starting again