### PR TITLE
[mediadownloader] encode  url if need

### DIFF
--- a/mediadownloader/src/HTTPProgressDownloader.py
+++ b/mediadownloader/src/HTTPProgressDownloader.py
@@ -8,7 +8,7 @@ class HTTPProgressDownloader(HTTPDownloader):
 		HTTPDownloader.__init__(self, url, fileOrName, *args, **kwargs)
 
 		# Save callback(s) locally
-		if writeProgress and type(writeProgress) is not list:
+		if writeProgress and not isinstance(writeProgress, list):
 			writeProgress = [writeProgress]
 		self.writeProgress = writeProgress
 

--- a/mediadownloader/src/MediaDownloader.py
+++ b/mediadownloader/src/MediaDownloader.py
@@ -106,6 +106,9 @@ def download(url, file, writeProgress=None, contextFactory=None,
 		else:
 			kwargs["headers"] = AuthHeaders
 
+	if isinstance(url, str):
+		url = url.encode("utf-8")
+
 	from .HTTPProgressDownloader import HTTPProgressDownloader
 	from twisted.internet import reactor
 


### PR DESCRIPTION
Traceback (most recent call last):
File "/usr/lib/enigma2/python/StartEnigma.py", line 217, in processDelay callback(*retval)
File
"/usr/lib/enigma2/python/Plugins/Extensions/MediaDownloader/MediaDownloader.py", line 191, in gotFilename
self.fetchFile()
File
"/usr/lib/enigma2/python/Plugins/Extensions/MediaDownloader/MediaDownloader.py", line 198, in fetchFile
d = download(
File
"/usr/lib/enigma2/python/Plugins/Extensions/MediaDownloader/MediaDownloader.py", line 116, in download
factory = HTTPProgressDownloader(url, file, writeProgress, *args, **kwargs)
File
"/usr/lib/enigma2/python/Plugins/Extensions/MediaDownloader/HTTPProgressDownloader.py", line 8, in init
HTTPDownloader.init(self, url, fileOrName, *args, **kwargs) File "/usr/lib/python3.9/site-packages/twisted/web/client.py", line 515, in init
File "/usr/lib/python3.9/site-packages/twisted/web/client.py", line 375, in init
File "/usr/lib/python3.9/site-packages/twisted/web/client.py", line 398, in setURL
File "/usr/lib/python3.9/site-packages/twisted/web/_newclient.py", line 634, in _ensureValidURI
TypeError: cannot use a bytes pattern on a string-like object