### PR TITLE
[autotimer] hidden option encoding

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -318,11 +318,6 @@ class AutoTimer:
 
 		# Workaround to allow search for umlauts if we know the encoding
 		match = timer.match.replace('\xc2\x86', '').replace('\xc2\x87', '')
-		#if timer.encoding != 'UTF-8':
-		#	try:
-		#		match = match.decode('UTF-8').encode(timer.encoding)
-		#	except:
-		#		pass
 
 		self.isIPTV = bool([service for service in timer.services if "%3a//" in service])
 

--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -318,11 +318,11 @@ class AutoTimer:
 
 		# Workaround to allow search for umlauts if we know the encoding
 		match = timer.match.replace('\xc2\x86', '').replace('\xc2\x87', '')
-		if timer.encoding != 'UTF-8':
-			try:
-				match = match.decode('UTF-8').encode(timer.encoding)
-			except UnicodeDecodeError:
-				pass
+		#if timer.encoding != 'UTF-8':
+		#	try:
+		#		match = match.decode('UTF-8').encode(timer.encoding)
+		#	except:
+		#		pass
 
 		self.isIPTV = bool([service for service in timer.services if "%3a//" in service])
 

--- a/autotimer/src/AutoTimerEditor.py
+++ b/autotimer/src/AutoTimerEditor.py
@@ -691,7 +691,7 @@ class AutoTimerEditor(Screen, ConfigListScreen, AutoTimerEditorBase):
 			))
 
 		list.extend((
-			getConfigListEntry(_("EPG encoding"), self.encoding),
+			#getConfigListEntry(_("EPG encoding"), self.encoding),
 			getConfigListEntry(_("Search type"), self.searchType),
 			getConfigListEntry(_("Search strictness"), self.searchCase),
 			getConfigListEntry(_("Timer type"), self.justplay),

--- a/autotimer/src/AutoTimerEditor.py
+++ b/autotimer/src/AutoTimerEditor.py
@@ -691,7 +691,6 @@ class AutoTimerEditor(Screen, ConfigListScreen, AutoTimerEditorBase):
 			))
 
 		list.extend((
-			#getConfigListEntry(_("EPG encoding"), self.encoding),
 			getConfigListEntry(_("Search type"), self.searchType),
 			getConfigListEntry(_("Search strictness"), self.searchCase),
 			getConfigListEntry(_("Timer type"), self.justplay),


### PR DESCRIPTION
-this need for python3
File
"/usr/lib/enigma2/python/Plugins/Extensions/AutoTimer/AutoTimer.py", line 322, in parseTimer

builtins.AttributeError: 'str' object has no attribute 'decode'