### PR TITLE
shoutcast: Ignore incorrect utf-8 encoding in recording status

### DIFF
--- a/shoutcast/src/plugin.py
+++ b/shoutcast/src/plugin.py
@@ -402,7 +402,7 @@ class SHOUTcastWidget(Screen):
 		self["key_red"].setText(_("Record"))
 
 	def streamripperDataAvail(self, data):
-		sData = data.decode().replace('\n', '')
+		sData = data.decode('utf-8', 'ignore').replace('\n', '')
 		self["console"].setText(_("Recording: %s") % sData)
 
 	def stopReloadStationListTimer(self):


### PR DESCRIPTION
It prevents the plugin from crashing when recording titles that contain special characters, such as ღ♫♥✬❥☽✸❖.

Thanks Stan
https://forums.openpli.org/user/47662-stan/