### PR TITLE
shoutcast: Use ISO 8859-1 format for station playlist

### DIFF
--- a/shoutcast/src/plugin.py
+++ b/shoutcast/src/plugin.py
@@ -658,7 +658,7 @@ class SHOUTcastWidget(Screen):
 	def callbackPLS(self, result):
 		self["headertext"].setText(self.headerTextString)
 		found = False
-		parts = str.split(result.decode(), "\n")
+		parts = str.split(result.decode('ISO 8859-1'), "\n")
 		for lines in parts:
 			if lines.find("File1=") != -1:
 				line = str.split(lines, "File1=")


### PR DESCRIPTION
It fixes ['utf-8' codec can't decode byte 0x** in position ***: invalid start byte], that comes up when selecting certain stations, e.g. some from genre Kids. Station playlists are in fact not coded in UTF-8.