### PR TITLE
autotimer: Drop superfluous addExternalChild() call

### DIFF
--- a/autotimer/src/plugin.py
+++ b/autotimer/src/plugin.py
@@ -104,16 +104,14 @@ def sessionstart(reason, **kwargs):
 			pass
 		if isOpenWebifInstalled():
 			try:
-				from Plugins.Extensions.WebInterface.WebChilds.Toplevel import addExternalChild
 				from .AutoTimerResource import AutoTimerDoParseResource, \
 					AutoTimerListAutoTimerResource, AutoTimerAddOrEditAutoTimerResource, \
 					AutoTimerRemoveAutoTimerResource, AutoTimerChangeSettingsResource, \
 					AutoTimerSettingsResource, AutoTimerSimulateResource, AutoTimerTestResource, \
-					AutoTimerUploadXMLConfigurationAutoTimerResource, AutoTimerAddXMLAutoTimerResource, API_VERSION
+					AutoTimerUploadXMLConfigurationAutoTimerResource, AutoTimerAddXMLAutoTimerResource
 			except ImportError as ie:
 				pass
 			else:
-				root = AutoTimerListAutoTimerResource()
 				root.putChild('parse', AutoTimerDoParseResource())
 				root.putChild('remove', AutoTimerRemoveAutoTimerResource())
 				root.putChild('upload_xmlconfiguration', AutoTimerUploadXMLConfigurationAutoTimerResource())
@@ -123,7 +121,6 @@ def sessionstart(reason, **kwargs):
 				root.putChild('set', AutoTimerChangeSettingsResource())
 				root.putChild('simulate', AutoTimerSimulateResource())
 				root.putChild('test', AutoTimerTestResource())
-				addExternalChild(("autotimer", root, "AutoTimer-Plugin", API_VERSION))
 				doLog("[AutoTimer] Use OpenWebif")
 
 


### PR DESCRIPTION
Does nothing when first argument is 'autotimer".
https://github.com/oe-alliance/OpenWebif/blob/main/plugin/pluginshook.src#L9

See also:
https://github.com/OpenPLi/enigma2-plugins/issues/646