### PR TITLE
[btdevicesmanager] auto reload E2 when first boot gbquad4kpro

### DIFF
--- a/btdevicesmanager/po/ru.po
+++ b/btdevicesmanager/po/ru.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: tuxbox-enigma 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-29 20:16+0100\n"
-"PO-Revision-Date: 2024-09-22 23:16+0300\n"
+"PO-Revision-Date: 2025-08-27 11:39+0300\n"
 "Last-Translator: Viacheslav Dikonov <sdiconov@mail.ru>\n"
 "Language-Team: openATV\n"
 "Language: ru\n"
@@ -13,75 +13,83 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 2.0.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#
 msgid "Audio Connect"
-msgstr "Подключить"
+msgstr "Аудио - подключение"
 
 msgid "Audio Off"
-msgstr ""
+msgstr "Аудио - выкл."
 
-#
-#, fuzzy
 msgid "Audio On"
-msgstr "Подключить"
+msgstr "Аудио - вкл."
 
 msgid "Bluetooth Devices Manager"
 msgstr "Менеджер Bluetooth-устройств"
 
 msgid "Bluetooth Devices Manager Setup"
-msgstr "Настройка менеджера Bluetooth-устройств"
+msgstr "Настройки менеджера Bluetooth-устройств"
 
 msgid "Can't not pair with selected device!"
 msgstr "Невозможно соединиться с выбранным устройством!"
 
-#
 msgid "Connect"
-msgstr "Соединиться"
+msgstr "Подключение"
 
-#
-#, fuzzy
 msgid "Connected"
-msgstr "Соединиться"
+msgstr "Подключено"
 
 msgid "Connection with:\n"
-msgstr "Соединение с:\n"
+msgstr "Подключено к :\n"
 
-#
 msgid "Disconnect"
-msgstr "Отсоединить"
+msgstr "Отключить"
 
 msgid "Disconnect with:\n"
-msgstr "Отсоединить от:\n"
+msgstr "Отключено от:\n"
 
-#, fuzzy
 msgid "Disconnecting please wait..."
-msgstr "Отсоединить от:\n"
+msgstr "Отключение - пожалуйста, подождите..."
 
 msgid "Exit"
 msgstr "Выход"
 
 msgid "Not connected to any device"
-msgstr "Нет соединения ни с одним устройством"
+msgstr "Не подключено ни одно устройство."
 
-#, fuzzy
+msgid "No connected to any device"
+msgstr "Не подключено ни одно устройство."
+
 msgid "Not connected"
-msgstr "Нет соединения ни с одним устройством"
+msgstr "Не подключено"
 
 msgid "Please Enter Passkey: \n"
 msgstr "Введите пин-код:\n"
 
-#, fuzzy
 msgid "Scan"
-msgstr "(Пере)сканировать"
+msgstr "Сканирование"
 
 msgid "Scanning for devices..."
-msgstr "Поиск устройств..."
+msgstr "Сканирование устройств..."
 
 msgid "This is bt devices manager"
-msgstr "Это менеджер Bluetooth-устройств"
+msgstr "Сканирование/настройки Bluetooth-устройств"
 
 msgid "Trying to pair with:"
 msgstr "Попытка соединения с:"
+
+msgid "Reload Enigma2"
+msgstr "Рестарт Enigma2"
+
+msgid "Reload Enigma2 when first boot"
+msgstr "Рестарт Enigma2 при первой загрузке"
+
+msgid "Press Menu+OK keys on the BT/IR remote control until the LED starts flashing. The 'GIGABLUE-BT20' remote will appear during the scan."
+msgstr "Нажмите одновременно кнопки Menu+OK на BT/IR пульте, пока светодиод не начнет мигать. 'GIGABLUE-BT20' пульт появится во время сканирования."
+
+msgid "Hold down the OK button on the BT remote control (bluetooth RCU06) until the LED flashes. The 'DEFINE' remote will appear during the scan."
+msgstr "Нажмите и удерживайте кнопку ОК на BT пульте (bluetooth RCU06), пока светодиод не начнет мигать. The 'DEFINE' пульт появится во время сканирования."
+
+msgid "Press Info+OK keys on the BT/IR remote control until the LED starts flashing."
+msgstr "Нажмите одновременно кнопки Info+OK на BT/IR пульте, пока светодиод не начнет мигать."

--- a/btdevicesmanager/src/bluetoothctl.py
+++ b/btdevicesmanager/src/bluetoothctl.py
@@ -214,10 +214,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                [".*not available\r\n", "trust succe", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    [".*not available\r\n", "trust succe", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def remove(self, mac_address):
         """Remove paired device by mac address, return success of the operation."""
@@ -227,10 +231,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                ["not available", "Device has been removed", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    ["not available", "Device has been removed", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def connect(self, mac_address):
         """Try to connect to a device by mac address."""
@@ -240,10 +248,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                ["Failed to connect", "Connection successful", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    ["Failed to connect", "Connection successful", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def disconnect(self, mac_address):
         """Try to disconnect to a device by mac address."""
@@ -253,10 +265,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                ["Failed to disconnect", "Successful disconnected", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    ["Failed to disconnect", "Successful disconnected", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def agent_noinputnooutput(self):
         """Start agent"""

--- a/btdevicesmanager/src/plugin.py
+++ b/btdevicesmanager/src/plugin.py
@@ -30,6 +30,7 @@ from Components.Sources.StaticText import StaticText
 from Components.ActionMap import ActionMap
 from Components.config import config, ConfigText, ConfigSubsection, ConfigYesNo
 from Components.MenuList import MenuList
+from Components.SystemInfo import BoxInfo
 from Components.ServiceEventTracker import ServiceEventTracker
 from Plugins.Plugin import PluginDescriptor
 from Screens.Screen import Screen
@@ -43,6 +44,7 @@ config.btdevicesmanager = ConfigSubsection()
 config.btdevicesmanager.autostart = ConfigYesNo(default=False)
 config.btdevicesmanager.audioconnect = ConfigYesNo(default=False)
 config.btdevicesmanager.audioaddress = ConfigText(default="", fixed_size=False)
+config.btdevicesmanager.e2reload = ConfigYesNo(default=False)
 
 
 class BluetoothDevicesManagerSetup(Setup):
@@ -57,12 +59,13 @@ class BluetoothDevicesManager(Screen):
 			<ePixmap pixmap="skin_default/buttons/green.png" position="155,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="skin_default/buttons/yellow.png" position="305,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="skin_default/buttons/blue.png" position="455,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/key_menu.png" position="0,430" size="35,25" alphatest="on" />
 			<widget source="key_red" render="Label" position="5,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" foregroundColor="#ffffff" transparent="1" />
 			<widget source="key_green" render="Label" position="155,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" foregroundColor="#ffffff" transparent="1" />
 			<widget source="key_yellow" render="Label" position="305,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" foregroundColor="#ffffff" transparent="1" />
 			<widget source="key_blue" render="Label" position="455,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" foregroundColor="#ffffff" transparent="1" />
 			<widget name="devicelist" position="0,50" size="600,300" foregroundColor="#ffffff" zPosition="10" scrollbarMode="showOnDemand" transparent="1"/>
-			<widget name="ConnStatus" position="0,330" size="600,150" zPosition="1" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" foregroundColor="#ffffff" transparent="1" />
+			<widget name="ConnStatus" position="0,330" size="600,120" zPosition="1" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" foregroundColor="#ffffff" transparent="1" />
 		</screen>
 		"""
 
@@ -84,9 +87,9 @@ class BluetoothDevicesManager(Screen):
 
 		self["key_red"] = StaticText(_("Exit"))
 		self["key_green"] = StaticText(_("Scan"))
-		self["key_yellow"] = StaticText(_("Connect"))
+		self["key_yellow"] = StaticText("")
 		self["key_blue"] = StaticText("")
-		self["ConnStatus"] = Label(_("Not connected to any device"))
+		self["ConnStatus"] = Label(_("No connected to any device"))
 
 		self.devicelist = []
 		self["devicelist"] = MenuList(self.devicelist)
@@ -152,7 +155,14 @@ class BluetoothDevicesManager(Screen):
 		if self.devicelist:
 			self["ConnStatus"].setText("")
 		else:
-			self["ConnStatus"].setText(_("No connected to any device"))
+			info_text = ""
+			if BoxInfo.getItem("model") == "gbquad4kpro":
+				info_text = "\n" +_("Press Menu+OK keys on the BT/IR remote control until the LED starts flashing. The 'GIGABLUE-BT20' remote will appear during the scan.")
+			elif BoxInfo.getItem("model") == "gbtrio4kpro":
+				info_text = "\n" +_("Press Info+OK keys on the BT/IR remote control until the LED starts flashing.")
+			elif BoxInfo.getItem("model") == "sf8008":
+				info_text = "\n" +_("Hold down the OK button on the BT remote control (bluetooth RCU06) until the LED flashes. The 'DEFINE' remote will appear during the scan.")
+			self["ConnStatus"].setText(_("No connected to any device") + info_text)
 		self["devicelist"].setList(self.devicelist)
 		self.selectionChanged()
 
@@ -320,6 +330,20 @@ class BluetoothDevicesTask:
 		self.check_timer = eTimer()
 		self.check_timer.callback.append(self.poll)
 		self.check_timer.start(3600000)
+		if BoxInfo.getItem("model") == "gbquad4kpro" and config.btdevicesmanager.e2reload.value and not isfile("/tmp/.bt-reload.txt"):
+			try:
+				open("/tmp/.bt-reload.txt", 'wb').close()
+			except:
+				config.btdevicesmanager.e2reload.value = False
+				config.btdevicesmanager.e2reload.save()
+			self.e2reload_timer = eTimer()
+			self.e2reload_timer.callback.append(self.e2Reload)
+			self.e2reload_timer.start(40000, True)
+
+	def e2Reload(self):
+		import Screens.Standby
+		if not Screens.Standby.inStandby and not Screens.Standby.inTryQuitMainloop and not self.session.nav.getRecordings():
+			self.session.open(Screens.Standby.TryQuitMainloop, 3)
 
 	def __evStart(self):
 		curr_time = datetime.now()
@@ -335,8 +359,9 @@ class BluetoothDevicesTask:
 
 	def flush(self):
 		try:
-			pid = open("/var/run/aplay.pid").read().split()[0]
-			kill(int(pid), SIGUSR2)
+			if isfile("/var/run/aplay.pid"):
+				pid = open("/var/run/aplay.pid").read().split()[0]
+				kill(int(pid), SIGUSR2)
 		except Exception:
 			pass
 		self.timestamp = datetime.now()

--- a/btdevicesmanager/src/setup.xml
+++ b/btdevicesmanager/src/setup.xml
@@ -1,5 +1,6 @@
 <setupxml>
 	<setup key="BluetoothDevicesManager" showOpenWebIF="1" title="Bluetooth Devices Manager Setup">
 		<item level="0" text="Audio Connect" description="Audio Connect">config.btdevicesmanager.audioconnect</item>
+		<item level="0" text="Reload Enigma2" conditional="BoxInfo.getItem('model') == 'gbquad4kpro'" description="Reload Enigma2 when first boot">config.btdevicesmanager.e2reload</item>
 	</setup>
 </setupxml>


### PR DESCRIPTION
-this config(reload E2 after 40 sec.) yes/no(default no)

-add info text to pair BT remote control

-[bluetoothctl.py] add sanity check:
Traceback (most recent call last):
  File
"/usr/lib/enigma2/python/Components/ActionMap.py", line 56, in action

File
"/usr/lib/enigma2/python/Plugins/Extensions/BTDevicesManager/plugin.py", line 282, in keyYellow
    self._connect(current[1], current[2])
  File
"/usr/lib/enigma2/python/Plugins/Extensions/BTDevicesManager/plugin.py", line 259, in _connect
    iBluetoothctl.trust(mac_address)
  File
"/usr/lib/enigma2/python/Plugins/Extensions/BTDevicesManager/bluetoothctl.py", line 217, in trust
    res = self.process.expect(
  File
"/usr/lib/python3.9/site-packages/pexpect/spawnbase.py", line 354, in expect
    return self.expect_list(compiled_pattern_list,
  File
"/usr/lib/python3.9/site-packages/pexpect/spawnbase.py", line 383, in expect_list
    return exp.expect_loop(timeout)
  File
"/usr/lib/python3.9/site-packages/pexpect/expect.py", line 181, in expect_loop
    return self.timeout(e)
  File
"/usr/lib/python3.9/site-packages/pexpect/expect.py", line 144, in timeout
    raise exc
pexpect.exceptions.TIMEOUT: Timeout
exceeded.
<pexpect.pty_spawn.spawn object at 0xb1d507d8>