### PR TITLE
[btdevicesmanager] add info text to pair BT remote control

### DIFF
--- a/btdevicesmanager/src/bluetoothctl.py
+++ b/btdevicesmanager/src/bluetoothctl.py
@@ -214,10 +214,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                [".*not available\r\n", "trust succe", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    [".*not available\r\n", "trust succe", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def remove(self, mac_address):
         """Remove paired device by mac address, return success of the operation."""
@@ -227,10 +231,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                ["not available", "Device has been removed", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    ["not available", "Device has been removed", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def connect(self, mac_address):
         """Try to connect to a device by mac address."""
@@ -240,10 +248,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                ["Failed to connect", "Connection successful", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    ["Failed to connect", "Connection successful", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def disconnect(self, mac_address):
         """Try to disconnect to a device by mac address."""
@@ -253,10 +265,14 @@ class Bluetoothctl:
             print(e)
             return False
         else:
-            res = self.process.expect(
-                ["Failed to disconnect", "Successful disconnected", EOF]
-            )
-            return res == 1
+            try:
+                res = self.process.expect(
+                    ["Failed to disconnect", "Successful disconnected", EOF]
+                )
+                return res == 1
+            except Exception as e:
+                print(e)
+                return False
 
     def agent_noinputnooutput(self):
         """Start agent"""

--- a/btdevicesmanager/src/plugin.py
+++ b/btdevicesmanager/src/plugin.py
@@ -88,7 +88,7 @@ class BluetoothDevicesManager(Screen):
 		self["key_green"] = StaticText(_("Scan"))
 		self["key_yellow"] = StaticText("")
 		self["key_blue"] = StaticText("")
-		self["ConnStatus"] = Label(_("No connected to any device"))
+		self["ConnStatus"] = Label(_("Not connected to any device"))
 
 		self.devicelist = []
 		self["devicelist"] = MenuList(self.devicelist)
@@ -161,7 +161,7 @@ class BluetoothDevicesManager(Screen):
 				info_text = "\n" +_("Press Info+OK keys on the BT/IR remote control until the LED starts flashing.")
 			elif BoxInfo.getItem("model") == "sf8008":
 				info_text = "\n" +_("Hold down the OK button on the BT remote control (bluetooth RCU06) until the LED flashes. The 'DEFINE' remote will appear during the scan.")
-			self["ConnStatus"].setText(_("No connected to any device") + info_text)
+			self["ConnStatus"].setText(_("Not connected to any device") + info_text)
 		self["devicelist"].setList(self.devicelist)
 		self.selectionChanged()
 

--- a/btdevicesmanager/src/plugin.py
+++ b/btdevicesmanager/src/plugin.py
@@ -30,6 +30,7 @@ from Components.Sources.StaticText import StaticText
 from Components.ActionMap import ActionMap
 from Components.config import config, ConfigText, ConfigSubsection, ConfigYesNo
 from Components.MenuList import MenuList
+from Components.SystemInfo import BoxInfo
 from Components.ServiceEventTracker import ServiceEventTracker
 from Plugins.Plugin import PluginDescriptor
 from Screens.Screen import Screen
@@ -57,12 +58,13 @@ class BluetoothDevicesManager(Screen):
 			<ePixmap pixmap="skin_default/buttons/green.png" position="155,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="skin_default/buttons/yellow.png" position="305,0" size="140,40" alphatest="on" />
 			<ePixmap pixmap="skin_default/buttons/blue.png" position="455,0" size="140,40" alphatest="on" />
+			<ePixmap pixmap="skin_default/buttons/key_menu.png" position="0,430" size="35,25" alphatest="on" />
 			<widget source="key_red" render="Label" position="5,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" foregroundColor="#ffffff" transparent="1" />
 			<widget source="key_green" render="Label" position="155,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#1f771f" foregroundColor="#ffffff" transparent="1" />
 			<widget source="key_yellow" render="Label" position="305,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#a08500" foregroundColor="#ffffff" transparent="1" />
 			<widget source="key_blue" render="Label" position="455,0" zPosition="1" size="140,40" font="Regular;20" halign="center" valign="center" backgroundColor="#18188b" foregroundColor="#ffffff" transparent="1" />
 			<widget name="devicelist" position="0,50" size="600,300" foregroundColor="#ffffff" zPosition="10" scrollbarMode="showOnDemand" transparent="1"/>
-			<widget name="ConnStatus" position="0,330" size="600,150" zPosition="1" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" foregroundColor="#ffffff" transparent="1" />
+			<widget name="ConnStatus" position="0,330" size="600,120" zPosition="1" font="Regular;20" halign="center" valign="center" backgroundColor="#9f1313" foregroundColor="#ffffff" transparent="1" />
 		</screen>
 		"""
 
@@ -84,9 +86,9 @@ class BluetoothDevicesManager(Screen):
 
 		self["key_red"] = StaticText(_("Exit"))
 		self["key_green"] = StaticText(_("Scan"))
-		self["key_yellow"] = StaticText(_("Connect"))
+		self["key_yellow"] = StaticText("")
 		self["key_blue"] = StaticText("")
-		self["ConnStatus"] = Label(_("Not connected to any device"))
+		self["ConnStatus"] = Label(_("No connected to any device"))
 
 		self.devicelist = []
 		self["devicelist"] = MenuList(self.devicelist)
@@ -152,7 +154,14 @@ class BluetoothDevicesManager(Screen):
 		if self.devicelist:
 			self["ConnStatus"].setText("")
 		else:
-			self["ConnStatus"].setText(_("No connected to any device"))
+			info_text = ""
+			if BoxInfo.getItem("model") == "gbquad4kpro":
+				info_text = "\n" +_("Press Menu+OK keys on the BT/IR remote control until the LED starts flashing. The 'GIGABLUE-BT20' remote will appear during the scan.")
+			elif BoxInfo.getItem("model") == "gbtrio4kpro":
+				info_text = "\n" +_("Press Info+OK keys on the BT/IR remote control until the LED starts flashing.")
+			elif BoxInfo.getItem("model") == "sf8008":
+				info_text = "\n" +_("Hold down the OK button on the BT remote control (bluetooth RCU06) until the LED flashes. The 'DEFINE' remote will appear during the scan.")
+			self["ConnStatus"].setText(_("No connected to any device") + info_text)
 		self["devicelist"].setList(self.devicelist)
 		self.selectionChanged()
 
@@ -335,8 +344,9 @@ class BluetoothDevicesTask:
 
 	def flush(self):
 		try:
-			pid = open("/var/run/aplay.pid").read().split()[0]
-			kill(int(pid), SIGUSR2)
+			if isfile("/var/run/aplay.pid"):
+				pid = open("/var/run/aplay.pid").read().split()[0]
+				kill(int(pid), SIGUSR2)
 		except Exception:
 			pass
 		self.timestamp = datetime.now()

--- a/btdevicesmanager/src/plugin.py
+++ b/btdevicesmanager/src/plugin.py
@@ -159,8 +159,8 @@ class BluetoothDevicesManager(Screen):
 				info_text = "\n" +_("Press Menu+OK keys on the BT/IR remote control until the LED starts flashing. The 'GIGABLUE-BT20' remote will appear during the scan.")
 			elif BoxInfo.getItem("model") == "gbtrio4kpro":
 				info_text = "\n" +_("Press Info+OK keys on the BT/IR remote control until the LED starts flashing.")
-			elif BoxInfo.getItem("model") == "sf8008":
-				info_text = "\n" +_("Hold down the OK button on the BT remote control (bluetooth RCU06) until the LED flashes. The 'DEFINE' remote will appear during the scan.")
+			#elif BoxInfo.getItem("model") == "sf8008":
+			#	info_text = "\n" +_("Hold down the OK button on the BT remote control (bluetooth RCU06) until the LED flashes. The 'DEFINE' remote will appear during the scan.")
 			self["ConnStatus"].setText(_("Not connected to any device") + info_text)
 		self["devicelist"].setList(self.devicelist)
 		self.selectionChanged()


### PR DESCRIPTION
-also [bluetoothctl.py] add sanity check:
Traceback (most recent call last):
File
"/usr/lib/enigma2/python/Components/ActionMap.py", line 56, in action

File
"/usr/lib/enigma2/python/Plugins/Extensions/BTDevicesManager/plugin.py", line 282, in keyYellow
self._connect(current[1], current[2])
File
"/usr/lib/enigma2/python/Plugins/Extensions/BTDevicesManager/plugin.py", line 259, in _connect
iBluetoothctl.trust(mac_address)
File

"/usr/lib/enigma2/python/Plugins/Extensions/BTDevicesManager/bluetoothctl.py", line 217, in trust
res = self.process.expect(
File
"/usr/lib/python3.9/site-packages/pexpect/spawnbase.py", line 354, in expect
return self.expect_list(compiled_pattern_list,
File
"/usr/lib/python3.9/site-packages/pexpect/spawnbase.py", line 383, in expect_list
return exp.expect_loop(timeout)
File
"/usr/lib/python3.9/site-packages/pexpect/expect.py", line 181, in expect_loop
return self.timeout(e)
File
"/usr/lib/python3.9/site-packages/pexpect/expect.py", line 144, in timeout
raise exc
pexpect.exceptions.TIMEOUT: Timeout
exceeded.
<pexpect.pty_spawn.spawn object at 0xb1d507d8>