### PR TITLE
EPGRefresh - restore previous service before AutoTimer start and upda…

### DIFF
--- a/epgrefresh/src/EPGRefresh.py
+++ b/epgrefresh/src/EPGRefresh.py
@@ -281,6 +281,7 @@ class EPGRefresh:
 					except:
 						pass
 		if config.plugins.epgrefresh.parse_autotimer.value:
+			self.maybeStopAdapter()
 			try:
 				from Plugins.Extensions.AutoTimer.plugin import autotimer
 				if autotimer is None:
@@ -465,7 +466,12 @@ class EPGRefresh:
 				servtxt = servtxt + 2 * ' ' + ngettext("... %d more service", "... %d more services", servcounter - LISTMAX) % (servcounter - LISTMAX) + '\n'
 			last_text = "%s / %s" % (ngettext("Remaining %d service", "Remaining %d services", servcounter) % servcounter, ngettext("%d:%02d min", "%d:%02d mins", remaining_time / 60) % (remaining_time / 60, remaining_time % 60))
 			if servcounter == 0:
-				text = first_text + _("Scanning last service. Please wait.")
+				if config.plugins.epgrefresh.parse_autotimer.value and not self.refreshAdapter:
+					text = first_text + _("\nRunning AutoTimer. Please wait.")
+				else:
+					text = first_text + _("Scanning last service. Please wait.")
+					if config.plugins.epgrefresh.parse_autotimer.value:
+						text += "\n\nAutoTimer will start after completion."
 			else:
 				text = first_text + _("Following Services have to be scanned:") + '\n' + servtxt + last_text
 			session.openWithCallback(self.msgClosed, MessageBox, text, MessageBox.TYPE_YESNO)

--- a/epgrefresh/src/EPGRefresh.py
+++ b/epgrefresh/src/EPGRefresh.py
@@ -471,7 +471,7 @@ class EPGRefresh:
 				else:
 					text = first_text + _("Scanning last service. Please wait.")
 					if config.plugins.epgrefresh.parse_autotimer.value:
-						text += "\n\nAutoTimer will start after completion."
+						text += _("\n\nAutoTimer will start after completion.")
 			else:
 				text = first_text + _("Following Services have to be scanned:") + '\n' + servtxt + last_text
 			session.openWithCallback(self.msgClosed, MessageBox, text, MessageBox.TYPE_YESNO)


### PR DESCRIPTION
…te status message.

- If AutoTimer is configured to run after EPGRefresh, the last scanned service remains displayed for the entire AutoTimer runtime, which can last several minutes.