### PR TITLE
EPGRefresh - Fix previous service restore after scheduled wakeup

### DIFF
--- a/epgrefresh/src/EPGRefresh.py
+++ b/epgrefresh/src/EPGRefresh.py
@@ -281,7 +281,7 @@ class EPGRefresh:
 					except:
 						pass
 		if config.plugins.epgrefresh.parse_autotimer.value:
-			self.maybeStopAdapter()
+			self.refreshAdapter.play(self.refreshAdapter.previousService)
 			try:
 				from Plugins.Extensions.AutoTimer.plugin import autotimer
 				if autotimer is None:

--- a/epgrefresh/src/MainPictureAdapter.py
+++ b/epgrefresh/src/MainPictureAdapter.py
@@ -30,8 +30,10 @@ class MainPictureAdapter:
 				Notifications.AddPopup(_("EPG refresh starts scanning channels."), MessageBox.TYPE_INFO, 4, NOTIFICATIONID)
 			except:
 				pass
+		self.wasInStandby = None
 		self.previousService = self.navcore.getCurrentlyPlayingServiceOrGroup()
 		if self.previousService is None and Screens.Standby.inStandby:
+			self.wasInStandby = True
 			self.previousService = eServiceReference(config.tv.lastservice.value)
 		try:
 			self.lastCount = Components.ServiceEventTracker.InfoBarCount
@@ -58,7 +60,13 @@ class MainPictureAdapter:
 				self.rotorTimer.start(1500, True)
 		else:
 			if self.previousService is not None:
-				self.navcore.playService(self.previousService)
+				if self.wasInStandby:
+					from Screens.InfoBar import InfoBar
+					csel = InfoBar.instance and InfoBar.instance.servicelist
+					if csel:
+						csel.servicelist.setCurrent(self.previousService, adjust=False)
+						self.previousService = csel.getCurrentSelection()
+				self.navcore.playService(self.previousService, forceRestart=self.wasInStandby)
 				config.tv.lastservice.value = self.previousService.toString()
 				config.tv.lastservice.save()
 			else:


### PR DESCRIPTION
- when EPGRefresh starts after a scheduled wakeup to standby, there is no currently playing service, so the previous service is restored from config.tv.lastservice. If the box is then woken up before EPGRefresh finishes, the service itself is restored correctly, but without the proper servicelist selection context. This can cause channel-number renderers to show "---".