### PR TITLE
[AutoTimer] force use extended description if short is empty

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -475,7 +475,7 @@ class AutoTimer:
 				continue
 
 			# Set short description to equal extended description if it is empty.
-			if not shortdesc and timer.descShortEqualExt and extdesc:
+			if not shortdesc  and extdesc and (not timer.avoidDuplicateDescription or timer.descShortEqualExt):
 				shortdesc = extdesc
 
 			# Convert begin time


### PR DESCRIPTION
-When "Require description to be unique" disabled always set extended description if short description is empty else enable option "Description - short equal extended for match".